### PR TITLE
feat: fix thumb offset on first recomposition

### DIFF
--- a/.run/browser.run.xml
+++ b/.run/browser.run.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="wasmJsBrowserRun" />
+          <option value="wasmJsBrowserDevelopmentRun" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import dev.zt64.compose.pipette.util.hsvValue
@@ -116,8 +116,8 @@ public fun CircularColorPicker(
     Box(
         modifier = modifier
             .size(128.dp)
-            .onGloballyPositioned {
-                radius = it.size.width.toFloat() / 2f
+            .onSizeChanged {
+                radius = it.width / 2f
             }
             .pointerInput(Unit) {
                 detectTapGestures { tapPosition ->
@@ -163,19 +163,15 @@ public fun CircularColorPicker(
                 }
             }
     ) {
-        val position = remember(hue, saturation, radius) {
-            val angle = hue * (PI / 180).toFloat()
-            val distance = saturation * radius
-
-            Offset(
-                x = radius + distance * cos(angle),
-                y = radius + distance * sin(angle)
-            )
-        }
-
         Box(
             modifier = Modifier.offset {
-                IntOffset(position.x.roundToInt(), position.y.roundToInt())
+                val angle = hue * (PI / 180).toFloat()
+                val distance = saturation * radius
+
+                IntOffset(
+                    x = (radius + distance * cos(angle)).roundToInt(),
+                    y = (radius + distance * sin(angle)).roundToInt()
+                )
             }
         ) {
             thumb()

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/SquareColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/SquareColorPicker.kt
@@ -120,15 +120,12 @@ public fun SquareColorPicker(
                 }
             }
     ) {
-        val offset = remember(saturation, value, size) {
-            val x = saturation * size.width
-            val y = size.height - value * size.height
-            Offset(x, y)
-        }
-
         Box(
             modifier = Modifier.offset {
-                IntOffset(offset.x.roundToInt(), offset.y.roundToInt())
+                IntOffset(
+                    x = (saturation * size.width).roundToInt(),
+                    y = (size.height - value * size.height).roundToInt()
+                )
             }
         ) {
             thumb()

--- a/sample/src/commonMain/kotlin/dev/zt64/compose/pipette/sample/Sample.kt
+++ b/sample/src/commonMain/kotlin/dev/zt64/compose/pipette/sample/Sample.kt
@@ -267,7 +267,7 @@ fun Sample() {
                             val h = (0..359).random().toFloat()
                             val s = (20..100).random().toFloat() / 100f
 
-                            hsvColor = HsvColor(h, s, 1f)
+                            hsvColor = HsvColor(h, s, hsvColor.value)
                         }
                     ) {
                         Icon(


### PR DESCRIPTION
Changes thumb offset calculation to do everything inside the `.offset {}` modifier. Otherwise, `remember`ing the offset calculation will result in the first frame having the incorrect offset. AFAIK doing it like this shouldn't result in any extra recompositions.

Funnily enough, it was already done this way for `RingColorPicker`, but not `CircularColorPicker` or `CircularColorPicker`.

Also,
- Change the `browser` IDE run task to use the `wasmJsBrowserDevelopmentRun` task (`wasmJsBrowserRun` doesn't work)
- Preserve the lightness of HSV in the sample upon randomizing (was kinda annoying)