### PR TITLE
Feature: change thumb color based on background

### DIFF
--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/ColorPickerDefaults.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/ColorPickerDefaults.kt
@@ -36,7 +36,7 @@ public object ColorPickerDefaults {
 
             // Draw the border
             drawCircle(
-                color = color.contrastingColor(),
+                color = color.contrastingColor,
                 radius = radius.toPx(),
                 alpha = 0.5f,
                 style = Stroke(1.dp.toPx())
@@ -45,8 +45,10 @@ public object ColorPickerDefaults {
     }
 }
 
-internal fun Color.contrastingColor(): Color =
-    if (this.isDark()) Color.White else Color.Black
+internal val Color.contrastingColor: Color
+    get() = if (this.isDark()) Color.White else Color.Black
 
-internal fun Color.isDark(): Boolean =
-    0.2126 * this.red + 0.7152 * this.green + 0.0722 * this.blue < .5f
+internal fun Color.isDark(): Boolean {
+    return 0.2126 * this.red + 0.7152 * this.green + 0.0722 * this.blue < .5f
+}
+


### PR DESCRIPTION
When the selected color is light, a black thumb is used, when it is dark, a white thumb is used.
This ensures the thumb is always easily visible.

[contrast.webm](https://github.com/user-attachments/assets/9c4010a2-f8d3-4a87-b820-6277a2f909b0)
