### PR TITLE
HSV Color fixes

### DIFF
--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/HsvColor.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/HsvColor.kt
@@ -108,7 +108,7 @@ public value class HsvColor private constructor(public val packedValue: ULong) {
     public companion object {
         public val Saver: Saver<HsvColor, Long> = Saver(
             save = { it.packedValue.toLong() },
-            restore = { HsvColor(it) }
+            restore = { HsvColor(it.toULong()) }
         )
 
         private fun hsvToRgbComponent(n: Int, h: Float, s: Float, v: Float): Float {

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/HsvColor.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/HsvColor.kt
@@ -162,8 +162,9 @@ public fun HsvColor(color: Long): HsvColor {
         else -> 0f
     } * 60f
 
+    val positiveHue = if (hue < 0f) hue + 360f else hue
     val saturation = if (max == 0f) 0f else 1 - min / max
     val value = max
 
-    return HsvColor(hue, saturation, value)
+    return HsvColor(positiveHue, saturation, value)
 }


### PR DESCRIPTION
2 fixes:

**Negative hue**: for some colors, e.g. `HsvColor(Color(0xFFf032e6))`, the resulting HSV color was incorrect due to a negative hue. Offsetting negative hues by 360 degrees fixes this issue.

**Wrong restored after save**: after doing a screen rotation, the color changed to another color. This was due to the usage of a wrong `HsvColor` constructor in the `Saver`: `public fun HsvColor(color: Long): HsvColor` was used instead of `private constructor(public val packedValue: ULong)`. Casting the value to a `ULong` fixes this.
Having both a `Long` and `ULong` constructor feels quite error-prone, but since the `ULong` constructor is private, this problem is contained to this file.