### PR TITLE
fix: ignore out of bounds gestures

### DIFF
--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
@@ -121,12 +121,10 @@ public fun CircularColorPicker(
 
                     // Continue dragging
                     while (change != null && change.pressed) {
+                        change.consume()
+                        val adjustedPosition = clampPositionToRadius(change.position, center, radius)
+                        updateColorFromPosition(adjustedPosition, center, radius, onColorChange)
                         change = awaitDragOrCancellation(change.id)
-                        if (change != null && change.pressed) {
-                            change.consume()
-                            val adjustedPosition = clampPositionToRadius(change.position, center, radius)
-                            updateColorFromPosition(adjustedPosition, center, radius, onColorChange)
-                        }
                     }
 
                     scope.launch {

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/CircularColorPicker.kt
@@ -173,6 +173,8 @@ public fun CircularColorPicker(
     }
 }
 
+private const val RAD_TO_DEG = (180 / PI).toFloat()
+
 /**
  * Get the color for a given position in the circular color picker.
  *
@@ -184,10 +186,9 @@ private inline fun updateColorFromPosition(
     radius: Float,
     onResult: (hue: Float, saturation: Float) -> Unit
 ) {
-    val center = Offset(radius, radius)
     val offset = position - center
 
-    val degrees = atan2(offset.y, offset.x) * (180 / PI).toFloat()
+    val degrees = atan2(offset.y, offset.x) * RAD_TO_DEG
     val centerAngle = (degrees + 360) % 360
     val distance = offset.getDistance()
     val saturation = (distance / radius).coerceIn(0f, 1f)

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/RingColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/RingColorPicker.kt
@@ -144,10 +144,8 @@ public fun RingColorPicker(
                     }
 
                     while (change != null && change.pressed) {
+                        updateHandlePosition(change.position)
                         change = awaitDragOrCancellation(change.id)
-                        if (change != null && change.pressed) {
-                            updateHandlePosition(change.position)
-                        }
                     }
 
                     scope.launch {

--- a/core/src/commonMain/kotlin/dev/zt64/compose/pipette/RingColorPicker.kt
+++ b/core/src/commonMain/kotlin/dev/zt64/compose/pipette/RingColorPicker.kt
@@ -1,8 +1,7 @@
 package dev.zt64.compose.pipette
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.*
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -18,9 +17,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.*
 import kotlinx.coroutines.launch
 import kotlin.math.*
 
@@ -121,36 +118,43 @@ public fun RingColorPicker(
                 center = Offset(it.width / 2f, it.height / 2f)
             }
             .pointerInput(Unit) {
-                detectTapGestures { offset ->
-                    updateHandlePosition(offset)
-                    onColorChangeFinished()
-                }
-            }
-            .pointerInput(Unit) {
-                var interaction: DragInteraction.Start? = null
+                awaitEachGesture {
+                    val down = awaitFirstDown()
+                    val downPosition = down.position
+                    val center = size.center.toOffset()
 
-                detectDragGestures(
-                    onDragStart = {
-                        scope.launch {
-                            interaction = DragInteraction.Start()
-                            interactionSource.emit(interaction)
-                        }
-                    },
-                    onDragEnd = {
-                        scope.launch {
-                            interaction?.let { interactionSource.emit(DragInteraction.Stop(it)) }
-                        }
-                        onColorChangeFinished()
-                    },
-                    onDragCancel = {
-                        scope.launch {
-                            interaction?.let { interactionSource.emit(DragInteraction.Cancel(it)) }
-                        }
-                        onColorChangeFinished()
+                    val distanceSquared = (downPosition - center).getDistanceSquared()
+                    val halfStroke = strokeWidth / 2f
+                    val innerRadiusSquared = (radius - halfStroke) * (radius - halfStroke)
+                    val outerRadiusSquared = (radius + halfStroke) * (radius + halfStroke)
+
+                    if (distanceSquared !in innerRadiusSquared..outerRadiusSquared) return@awaitEachGesture
+
+                    // Handle initial tap
+                    updateHandlePosition(downPosition)
+
+                    val interaction = DragInteraction.Start()
+                    scope.launch {
+                        interactionSource.emit(interaction)
                     }
-                ) { change, _ ->
-                    change.consume()
-                    updateHandlePosition(change.position)
+
+                    var change = awaitTouchSlopOrCancellation(down.id) { change, _ ->
+                        change.consume()
+                        updateHandlePosition(change.position)
+                    }
+
+                    while (change != null && change.pressed) {
+                        change = awaitDragOrCancellation(change.id)
+                        if (change != null && change.pressed) {
+                            updateHandlePosition(change.position)
+                        }
+                    }
+
+                    scope.launch {
+                        interactionSource.emit(DragInteraction.Stop(interaction))
+                    }
+
+                    onColorChangeFinished()
                 }
             }
             .drawWithCache {

--- a/core/src/commonTest/kotlin/dev/zt64/compose/pipette/ColorPickerTest.kt
+++ b/core/src/commonTest/kotlin/dev/zt64/compose/pipette/ColorPickerTest.kt
@@ -90,4 +90,47 @@ class ColorPickerTest {
         assertEquals(1f, color.saturation)
         assertEquals(1f, color.value)
     }
+
+    // Test that clicking in the center of the ring does not change the color
+    @Test
+    fun testRingPickerBounds() = runComposeUiTest {
+        var color by mutableStateOf(HsvColor(Color.Red))
+
+        setContent {
+            RingColorPicker(
+                modifier = Modifier.testTag(TEST_TAG),
+                color = { color },
+                onColorChange = { color = it }
+            )
+        }
+
+        onNodeWithTag(TEST_TAG).performTouchInput {
+            // click in center of the ring
+            click(Offset(width / 2f, height / 3f))
+        }
+
+        // the color should remain unchanged
+        assertEquals(Color.Red, color.toColor())
+    }
+
+    @Test
+    fun testCirclePickerBounds() = runComposeUiTest {
+        var color by mutableStateOf(HsvColor(Color.Red))
+
+        setContent {
+            CircularColorPicker(
+                modifier = Modifier.testTag(TEST_TAG),
+                color = { color },
+                onColorChange = { color = it }
+            )
+        }
+
+        onNodeWithTag(TEST_TAG).performTouchInput {
+            // click in the center of the circle
+            click(Offset(0f, 0f))
+        }
+
+        // the color should remain unchanged
+        assertEquals(Color.Red, color.toColor())
+    }
 }


### PR DESCRIPTION
This PR rewrites the color picker input handling to allow full control on consuming input. 

* CircularColorPicker will now ignore taps on the corners.
* RingColorPicker will ignore touches in the center empty space and on the outside corners. 

Several optimizations have also been made to color-to-position calculations. 

Closes #112 